### PR TITLE
Update reconnect loop

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -573,7 +573,8 @@ func (conn *Conn) listen() {
 
 func (conn *Conn) reconnectLoop() {
 	sleep := time.Second
-	for i := 1; conn.ReconnectionAttempts == 0 || i <= conn.ReconnectionAttempts; i++ {
+	attempt := 1
+	for {
 		conn.nodeIdx += 1
 		conn.nodeIdx %= len(conn.nodes)
 
@@ -593,7 +594,12 @@ func (conn *Conn) reconnectLoop() {
 			break
 		}
 
-		conn.logInfo("Attempt %d: try to reconnect in %d second(s)...", i, sleep/time.Second)
+		if attempt == conn.ReconnectionAttempts {
+			conn.logInfo("Attempt %d failed. \n", attempt)
+			break
+		}
+
+		conn.logInfo("Attempt %d failed. Try to reconnect in %d second(s)...", attempt, sleep/time.Second)
 
 		time.Sleep(sleep)
 
@@ -602,6 +608,8 @@ func (conn *Conn) reconnectLoop() {
 		if sleep > maxReconnectSleep {
 			sleep = maxReconnectSleep
 		}
+
+		attempt++
 	}
 }
 

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package thingsdb
 
 //Version exposes the go-thingsdb version
-const Version = "1.0.4"
+const Version = "1.0.5"
 
 //Publish module:
 //


### PR DESCRIPTION
Break out of reconnect-loop based on the number of re-connection attempts should be evaluated after the `conn.connect`. This prevents an unnecessary sleep at the end of the cycle.